### PR TITLE
Downgrade regex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "elf",
  "hex",
  "rand",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ serial_test = "2.0.0"
 nix = "0.26.2"
 libc = "0.2"
 zeroize = { version = "1.6.0", default-features = false, features = ["zeroize_derive"] }
-regex = "1.10.2"
+regex = "1.9.6"
 
 [profile.firmware]
 inherits = "release"

--- a/coverage/Cargo.toml
+++ b/coverage/Cargo.toml
@@ -16,6 +16,6 @@ rand.workspace = true
 bit-vec = { workspace = true, features = ["serde"] }
 caliptra-builder.workspace = true
 elf.workspace = true
-# regex = "1.10.2"
+regex.workspace = true
 caliptra-image-types.workspace = true
 caliptra-drivers.workspace=true


### PR DESCRIPTION
Looks like svd2rust requires precise version of `regex` crate.
Let's downgrade it for now, it's a minor version, looks like it compiles at least. Once svd2rust upgrades, we will upgrade the version in Caliptra.